### PR TITLE
Return metaclass methods

### DIFF
--- a/src/main/groovy/com/citytechinc/aem/groovy/console/extension/impl/DefaultScriptMetaClassExtensionProvider.groovy
+++ b/src/main/groovy/com/citytechinc/aem/groovy/console/extension/impl/DefaultScriptMetaClassExtensionProvider.groovy
@@ -3,6 +3,7 @@ package com.citytechinc.aem.groovy.console.extension.impl
 import com.citytechinc.aem.groovy.console.api.ScriptMetaClassExtensionProvider
 import com.citytechinc.aem.groovy.console.table.Table
 import com.day.cq.replication.ReplicationActionType
+import com.day.cq.replication.ReplicationOptions
 import com.day.cq.replication.Replicator
 import com.day.cq.search.PredicateGroup
 import com.day.cq.search.QueryBuilder
@@ -111,12 +112,12 @@ class DefaultScriptMetaClassExtensionProvider implements ScriptMetaClassExtensio
                 serviceReferences.collect { bundleContext.getService(it) }
             }
 
-            delegate.activate = { String path ->
-                replicator.replicate(session, ReplicationActionType.ACTIVATE, path)
+            delegate.activate = { String path, ReplicationOptions options = null  ->
+                replicator.replicate(session, ReplicationActionType.ACTIVATE, path, options)
             }
 
-            delegate.deactivate = { String path ->
-                replicator.replicate(session, ReplicationActionType.DEACTIVATE, path)
+            delegate.deactivate = { String path, ReplicationOptions options = null  ->
+                replicator.replicate(session, ReplicationActionType.DEACTIVATE, path, options)
             }
 
             delegate.doWhileDisabled = { String componentClassName, Closure closure ->

--- a/src/test/groovy/com/citytechinc/aem/groovy/console/services/impl/DefaultGroovyConsoleServiceSpec.groovy
+++ b/src/test/groovy/com/citytechinc/aem/groovy/console/services/impl/DefaultGroovyConsoleServiceSpec.groovy
@@ -95,7 +95,7 @@ class DefaultGroovyConsoleServiceSpec extends ProsperSpec {
 
     void assertScriptResult(map) {
         assert !map.result
-        assert map.output == "BEER\n"
+        assert map.output == "BEER" + System.getProperty("line.separator")
         assert !map.exceptionStackTrace
         assert map.runningTime
     }


### PR DESCRIPTION
In a previous commit to make Meta-Class methods extendable, two documented methods were removed. Those methods were activate(path, options) and deactive(path, options). This change returns these methods so scripts are backwards compatible. 

I've also changed the assertScriptResult() test so that the test will work on Windows environments.