### PR TITLE
Upgrade to Groovy 2.4.5 to fix potential security issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Groovy 2.4.3 has a known security issue which was fixed in 2.4.4: https://issues.apache.org/jira/browse/GROOVY-7504

While this is hardly exploitable with AEM it can make customers nervous.