### PR TITLE
AEM 6.2-compatible OSGI package imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,14 @@
                         <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
                         <Export-Package>!*.impl,com.citytechinc.aem.groovy.console.*</Export-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <!-- Exported package versions differ in major version between AEM61 and AEM62 -->
+                        <Import-Package>
+                          com.day.cq.commons.jcr;version="[5.7,7)",
+                          com.day.cq.replication;version="[5.17,7)",
+                          com.day.cq.wcm.tags;version="[5.7,7)",
+                          org.apache.felix.scr;resolution:=optional,
+                          *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>
@@ -450,7 +458,7 @@
         <dependency>
             <groupId>com.citytechinc.aem.groovy.extension</groupId>
             <artifactId>aem-groovy-extension-bundle</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
fix OSGi package imports to be compatible with both AEM 6.1 and AEM 6.2
set dependency to org.apache.felix.scr to optional because it does no longer exist in AEM 6.2/SCR 2.0

please note that some few groovy scripts still depend on `org.apache.felix.scr.ScrService` - they have to be changed to do this using only the OSGi API, Felix SCR 2.0 does no longer export this service.

most of the sample groovy sample scripts still fail when calling some of the convenience methods like getPage(...) - but at least the OSGi bundles are starting.